### PR TITLE
Test improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: php
-dist: trusty
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
   - '7.2'
-  - 'hhvm'
+  - '7.3'
+  - '7.4'
+  - 'nightly'
+matrix:
+  allow_failures:
+    - php: nightly
 install:
-  - composer update
+  - composer install
 script:
  - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
-after_script: 
+after_script:
  - php vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,21 @@
             "email": "jordan@hall05.co.uk"
         }
     ],
-    "require": {},
+    "require": {
+        "php": ">=7.1"
+    },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "satooshi/php-coveralls": "^2.0"
+        "phpunit/phpunit": "^7.0 || ^8.0",
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {
         "psr-4": {
             "DivineOmega\\ReadingTime\\": "./src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "DivineOmega\\ReadingTime\\Tests\\": "./tests/Unit/"
         }
     }
 }

--- a/tests/Unit/ReadingTimeTest.php
+++ b/tests/Unit/ReadingTimeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace DivineOmega\ReadingTime\Tests;
+
 use DivineOmega\ReadingTime\ReadingTime;
 use PHPUnit\Framework\TestCase;
 
@@ -38,6 +40,6 @@ class ReadingTimeTest extends TestCase
         $wordPerMinute = 240;
         $text = file_get_contents(__DIR__.'/data/small.txt');
 
-        $this->assertEquals(20.5, (new ReadingTime($text))->setWordsPerMinute(240)->seconds());
+        $this->assertEquals(20.5, (new ReadingTime($text))->setWordsPerMinute($wordPerMinute)->seconds());
     }
 }


### PR DESCRIPTION
# Changed log
- Let this package require `php-7.1` version at least.
- Defining PHPUnit `^7.0 || ^8.0` versions to support different PHP versions.
- Add `*.cache` to ignore these related files to be under Git version control.
- The `composer.lock` is not under Git version control, and it's fine to use `composer install` command.
- The `satooshi/php-coveralls` package is deprecated. Using the `php-coveralls/php-coveralls` package instead.
- The `$wordPerMinute` variable is defined, but not used. Using it.