### PR TITLE
Return practical integer reading times

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.1', '8.5']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - run: composer update --prefer-dist --no-interaction
+      - run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/Jord-JD/php-reading-time.svg?branch=master)](https://travis-ci.org/Jord-JD/php-reading-time)
 [![Coverage Status](https://coveralls.io/repos/github/Jord-JD/php-reading-time/badge.svg?branch=master)](https://coveralls.io/github/Jord-JD/php-reading-time?branch=master)
-[![StyleCI](https://styleci.io/repos/128542116/shield?branch=master)](https://styleci.io/repos/128542116)
 
 This PHP library lets you easily calculate the reading time for a piece of text.
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": ">=7.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0 || ^8.0",
+    "phpunit/phpunit": "^7.0 || ^8.0 || ^9.6",
     "php-coveralls/php-coveralls": "^2.0"
   },
   "autoload": {
@@ -31,7 +31,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "3.0-dev"
+      "dev-master": "4.0-dev"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,6 @@
     <testsuites>
         <testsuite name="Unit Tests">
             <directory suffix="Test.php">./tests/Unit</directory>
-            <directory suffix="Test.php">./tests/Integration</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/ReadingTime.php
+++ b/src/ReadingTime.php
@@ -2,30 +2,36 @@
 
 namespace JordJD\ReadingTime;
 
+use InvalidArgumentException;
+
 class ReadingTime
 {
     private $content;
     private $wordsPerMinute = 200;
 
-    public function __construct($content)
+    public function __construct(string $content)
     {
         $this->content = $content;
     }
 
-    public function setWordsPerMinute($wordsPerMinute)
+    public function setWordsPerMinute(int $wordsPerMinute): self
     {
+        if ($wordsPerMinute <= 0) {
+            throw new InvalidArgumentException('Words per minute must be greater than zero.');
+        }
+
         $this->wordsPerMinute = $wordsPerMinute;
 
         return $this;
     }
 
-    public function minutes()
+    public function minutes(): int
     {
-        return str_word_count($this->content) / $this->wordsPerMinute;
+        return (int) ceil(str_word_count($this->content) / $this->wordsPerMinute);
     }
 
-    public function seconds()
+    public function seconds(): int
     {
-        return $this->minutes() * 60;
+        return (int) ceil((str_word_count($this->content) / $this->wordsPerMinute) * 60);
     }
 }

--- a/tests/Unit/ReadingTimeTest.php
+++ b/tests/Unit/ReadingTimeTest.php
@@ -11,28 +11,28 @@ class ReadingTimeTest extends TestCase
     {
         $text = file_get_contents(__DIR__.'/data/large.txt');
 
-        $this->assertEquals(9.7699999999999996, (new ReadingTime($text))->minutes());
+        $this->assertSame(10, (new ReadingTime($text))->minutes());
     }
 
     public function testLargeTextReadingTimeSeconds()
     {
         $text = file_get_contents(__DIR__.'/data/large.txt');
 
-        $this->assertEquals(586.19999999999993, (new ReadingTime($text))->seconds());
+        $this->assertSame(587, (new ReadingTime($text))->seconds());
     }
 
     public function testSmallTextReadingTimeMinutes()
     {
         $text = file_get_contents(__DIR__.'/data/small.txt');
 
-        $this->assertEquals(0.40999999999999998, (new ReadingTime($text))->minutes());
+        $this->assertSame(1, (new ReadingTime($text))->minutes());
     }
 
     public function testSmallTextReadingTimeSeconds()
     {
         $text = file_get_contents(__DIR__.'/data/small.txt');
 
-        $this->assertEquals(24.599999999999998, (new ReadingTime($text))->seconds());
+        $this->assertSame(25, (new ReadingTime($text))->seconds());
     }
 
     public function testSmallTextReadingTimeSecondsDifferentWordPerMinute()
@@ -40,6 +40,13 @@ class ReadingTimeTest extends TestCase
         $wordPerMinute = 240;
         $text = file_get_contents(__DIR__.'/data/small.txt');
 
-        $this->assertEquals(20.5, (new ReadingTime($text))->setWordsPerMinute($wordPerMinute)->seconds());
+        $this->assertSame(21, (new ReadingTime($text))->setWordsPerMinute($wordPerMinute)->seconds());
+    }
+
+    public function testWordsPerMinuteMustBePositive()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new ReadingTime('Some text'))->setWordsPerMinute(0);
     }
 }


### PR DESCRIPTION
## What changed

- returns rounded-up integer minutes and seconds suitable for display
- adds scalar parameter and return types
- rejects zero or negative reading speeds instead of dividing by zero
- updates tests and adds PHP 7.1/PHP 8.5 CI
- moves the branch alias to 4.0 because the return-type change is intentionally breaking

## Why

This resolves #2 and #3 and supersedes #5. A major release is planned because callers may currently depend on fractional values.

## Validation

- Composer JSON parsed successfully
- `git diff --check` passed
- GitHub Actions runs the updated unit suite on the supported floor and PHP 8.5